### PR TITLE
Extend XojoUnit for CI use

### DIFF
--- a/XojoUnit/TestFramework/Assert.xojo_code
+++ b/XojoUnit/TestFramework/Assert.xojo_code
@@ -52,8 +52,8 @@ Protected Class Assert
 		  actualSize = UBound(actual)
 		  
 		  If expectedSize <> actualSize Then
-		    Fail( "Expected Integer array Ubound <" + Str(expectedSize) + _
-		    "> but was <" + Str(actualSize) + ">.", _
+		    Fail( "Expected Integer array Ubound [" + Str(expectedSize) + _
+		    "] but was [" + Str(actualSize) + "].", _
 		    message)
 		    Return
 		  End If
@@ -111,8 +111,8 @@ Protected Class Assert
 		  actualSize = UBound(actual)
 		  
 		  If expectedSize <> actualSize Then
-		    Fail( "Expected Integer array Ubound <" + Str(expectedSize) + _
-		    "> but was <" + Str(actualSize) + ">.", _
+		    Fail( "Expected Integer array Ubound [" + Str(expectedSize) + _
+		    "] but was [" + Str(actualSize) + "].", _
 		    message)
 		    Return
 		  End If
@@ -148,8 +148,8 @@ Protected Class Assert
 		  actualSize = UBound(actual)
 		  
 		  If expectedSize <> actualSize Then
-		    Fail( "Expected String array Ubound <" + Str(expectedSize) + _
-		    "> but was <" + Str(actualSize) + ">.", _
+		    Fail( "Expected String array Ubound [" + Str(expectedSize) + _
+		    "] but was [" + Str(actualSize) + "].", _
 		    message)
 		    Return
 		  End If
@@ -223,7 +223,7 @@ Protected Class Assert
 		Private Function FailEqualMessage(expected As String, actual As String) As String
 		  Dim message As String
 		  
-		  message = "Expected <" + expected + "> but was <" + actual + ">."
+		  message = "Expected [" + expected + "] but was [" + actual + "]."
 		  
 		  Return message
 		End Function
@@ -232,7 +232,7 @@ Protected Class Assert
 	#tag Method, Flags = &h0
 		Sub IsFalse(condition As Boolean, message As String = "")
 		  If condition Then
-		    Fail("<false> expected, but was <true>.", message)
+		    Fail("[false] expected, but was [true].", message)
 		  Else
 		    Pass(message)
 		  End If
@@ -244,7 +244,7 @@ Protected Class Assert
 		  If anObject = Nil Then
 		    Pass(message)
 		  Else
-		    Fail("Object was expected to be <nil>, but was not.", message)
+		    Fail("Object was expected to be [nil], but was not.", message)
 		  End If
 		  
 		End Sub
@@ -255,7 +255,7 @@ Protected Class Assert
 		  If anObject <> Nil Then
 		    Pass(message)
 		  Else
-		    Fail("Expected value not to be <nil>, but was <nil>.", message)
+		    Fail("Expected value not to be [nil], but was [nil].", message)
 		  End If
 		  
 		End Sub
@@ -266,7 +266,7 @@ Protected Class Assert
 		  If condition Then
 		    Pass(message)
 		  Else
-		    Fail("<true> expected, but was <false>.", message)
+		    Fail("[true] expected, but was [false].", message)
 		  End If
 		End Sub
 	#tag EndMethod

--- a/XojoUnit/TestFramework/TestController.xojo_code
+++ b/XojoUnit/TestFramework/TestController.xojo_code
@@ -15,6 +15,39 @@ Protected Class TestController
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
+		Sub ExportTestResults(filePath As String)
+		  Dim f as FolderItem
+		  f = New FolderItem(filePath, FolderItem.PathTypeShell)
+		  Dim stream as BinaryStream
+		  If f <> Nil Then
+		    stream=BinaryStream.Create(f, True)
+		    stream.Write "<?xml version=""1.0"" encoding=""UTF-8"" ?>" + EndOfLine
+		    stream.Write "<testsuites>" + EndOfLine
+		    For Each tg As TestGroup In mTestGroups
+		      stream.Write "  <testsuite errors=""0"" skipped=""" + Str(tg.SkippedTestCount) + """ tests=""" + Str(tg.TestCount) + """ time=""" + Str(tg.Duration) + """ failures=""" + Str(tg.FailedTestCount) + """ name=""com.atlassian.bamboo.labels." + tg.Name + """>" + EndOfLine
+		      For Each tr As TestResult In tg.Results
+		        stream.Write "    <testcase name=""" + tr.TestName + """ duration=""" + Str(tr.Duration) + """>" + EndOfLine
+		        if tr.Result = TestResult.Skipped then
+		          stream.Write "       <skipped />" + EndOfLine
+		        end
+		        if tr.Result = TestResult.Failed then
+		          dim failMessage As string = tr.Message
+		          failMessage = ReplaceAll(failMessage, "<", "&lt;")
+		          failMessage = ReplaceAll(failMessage, ">", "&gt;")
+		          stream.Write "       <failure type=""xojo.AssertionFailedError"" message=""" + failMessage + """/>" + EndOfLine
+		        end
+		        stream.Write "    </testcase>" + EndOfLine
+		      Next
+		      stream.Write "  </testsuite>" + EndOfLine
+		    Next
+		    stream.Write "</testsuites>" + EndOfLine
+		    stream.Close
+		  End if
+		  
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
 		Sub LoadTestGroups()
 		  InitializeTestGroups
 		End Sub

--- a/XojoUnit/TestFramework/TestGroup.xojo_code
+++ b/XojoUnit/TestFramework/TestGroup.xojo_code
@@ -167,6 +167,23 @@ Protected Class TestGroup
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
+			  Dim _duration As Double = 0
+			  
+			  For Each tr As TestResult In mResults
+			    If tr.Result = TestResult.Passed Or tr.Result = TestResult.Failed Then
+			      _duration = _duration + tr.Duration
+			    End If
+			  Next
+			  
+			  Return _duration
+			End Get
+		#tag EndGetter
+		Duration As Double
+	#tag EndComputedProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
 			  Dim testCount As Integer
 			  
 			  For Each tr As TestResult In mResults

--- a/XojoUnit/TestWindow.xojo_window
+++ b/XojoUnit/TestWindow.xojo_window
@@ -798,6 +798,17 @@ End
 		  mController.LoadTestGroups
 		  
 		  PopulateTestGroups
+		  
+		  // Run unit tests now and exit?
+		  dim args(-1) as String
+		  args = Split(System.CommandLine().Lowercase(), " ")
+		  dim runUnitTest as Integer = args.IndexOf("--rununittests")
+		  if runUnitTest > 0 and Ubound(args) > runUnitTest then
+		    RunTests
+		    ExportTests args(runUnitTest + 1)
+		    Quit
+		  end
+		  
 		End Sub
 	#tag EndEvent
 

--- a/XojoUnit/TestWindow.xojo_window
+++ b/XojoUnit/TestWindow.xojo_window
@@ -839,6 +839,13 @@ End
 	#tag EndMenuHandler
 
 
+	#tag Method, Flags = &h0
+		Sub ExportTests(filePath As String)
+		  mController.ExportTestResults filePath
+		  
+		End Sub
+	#tag EndMethod
+
 	#tag Method, Flags = &h21
 		Private Sub PopulateTestGroups()
 		  // Add the test groups into the listbox
@@ -1035,6 +1042,17 @@ End
 		  Case "RunButton"
 		    RunTests
 		  Case "ExportButton"
+		    Dim dlg as New SaveAsDialog
+		    Dim f as FolderItem
+		    dlg.InitialDirectory = SpecialFolder.Documents
+		    dlg.promptText = "Save results as"
+		    dlg.SuggestedFileName = "results.xml"
+		    dlg.Title = "Save Results"
+		    dlg.Filter = "xml"
+		    f = dlg.ShowModal()
+		    If f <> Nil then
+		      ExportTests f.PosixPath
+		    End if
 		  End Select
 		End Sub
 	#tag EndEvent


### PR DESCRIPTION
When using Xojo in a Continuous Integration system, one wants to be able to run the unit tests from a script. This PR adds the ability to run all the tests from the command-line using --runUnitTests.

It also contains the code to make the Export button functional.

I have tested this for a few weeks in our CI system and it works well. Thanks!
