### PR TITLE
TestGroup: Use FullName as a default group name

### DIFF
--- a/Shared Resources/XojoUnit/TestFramework/TestGroup.xojo_code
+++ b/Shared Resources/XojoUnit/TestFramework/TestGroup.xojo_code
@@ -15,8 +15,8 @@ Protected Class TestGroup
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(controller As TestController, groupName As Text)
-		  Name = groupName
+		Sub Constructor(controller As TestController, groupName As Text = "")
+		  Name = If(groupName <> "", groupName, Introspection.GetType(Me).FullName.ToText)
 		  
 		  controller.AddGroup(Self)
 		  


### PR DESCRIPTION
I'm using XojoUnit in a project with many test groups.
It is handy if group names are automatically generated from the fully qualified class name.
