### PR TITLE
XojoUnitTestWindow: Improved so that custom TestController can be specified via Constructor

### DIFF
--- a/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
+++ b/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
@@ -790,7 +790,6 @@ End
 #tag WindowCode
 	#tag Event
 		Sub Open()
-		  mController = New DesktopTestController
 		  mController.LoadTestGroups
 		  
 		  PopulateTestGroups
@@ -845,6 +844,15 @@ End
 		End Function
 	#tag EndMenuHandler
 
+
+	#tag Method, Flags = &h0
+		Sub Constructor(controller As TestController = Nil)
+		  mController = If(controller <> Nil, controller, TestController(New DesktopTestController()))
+		  
+		  // Calling the overridden superclass constructor.
+		  Super.Constructor()
+		End Sub
+	#tag EndMethod
 
 	#tag Method, Flags = &h0
 		Sub ExportTests(filePath As String)


### PR DESCRIPTION
I fixed XojoUnitTestWindow (used in XojoUnit Desktop) so that custom TestController can be specified via window Constructor.
This makes possible to use custom (user-defined) TestController instead of directly modifying DesktopTestController included in XojoUnit.
This makes easy to update XojoUnit copied to my own project to the latest version available in this repository.
