### PR TITLE
Fixed command-line test interface

### DIFF
--- a/Desktop Project/XojoUnitDesktop.xojo_project
+++ b/Desktop Project/XojoUnitDesktop.xojo_project
@@ -1,5 +1,5 @@
 Type=Desktop
-RBProjectVersion=2016.02
+RBProjectVersion=2016.021
 MinIDEVersion=20070100
 Class=App;App.xojo_code;&h1BA8AB47;&h0;false
 Folder=XojoUnit;../Shared Resources/XojoUnit;&h2516B04D;&h0;false

--- a/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
+++ b/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
@@ -817,8 +817,7 @@ End
 		  Dim runUnitTest As Integer = args.IndexOf("--rununittests")
 		  If runUnitTest > 0 And Ubound(args) > runUnitTest Then
 		    RunTests
-		    ExportTests args(runUnitTest + 1)
-		    Quit
+		    self.exportFilePath = ConvertEncoding(args(runUnitTest + 1), Encodings.UTF8)
 		  End
 		End Sub
 	#tag EndEvent
@@ -951,6 +950,11 @@ End
 		  
 		End Sub
 	#tag EndMethod
+
+
+	#tag Property, Flags = &h21
+		Private exportFilePath As String
+	#tag EndProperty
 
 
 #tag EndWindowCode
@@ -1117,6 +1121,12 @@ End
 		  PassedCountLabel.Text = Str(Controller.PassedCount) + " (" + Format((Controller.PassedCount / testCount) * 100, "##.00") + "%)"
 		  FailedCountLabel.Text = Str(Controller.FailedCount) + " (" + Format((Controller.FailedCount / testCount) * 100, "##.00") + "%)"
 		  SkippedCountLabel.Text = Str(Controller.SkippedCount)
+		  
+		  // We were launched from the command-line, write out the results and quit
+		  if self.exportFilePath <> "" then
+		    ExportTests(self.exportFilePath)
+		    Quit
+		  end if
 		  
 		End Sub
 	#tag EndEvent


### PR DESCRIPTION
While working on my upcoming XDC talk, I noticed that the command-line interface in XojoUnit was not working properly. Namely, it was writing out an empty results file because it didn't have time to run the tests (they start with a timer).

We had fixed this at Lightspeed, but I forgot to propagate the fixes here. Hope you like them.

http://www.xojo.com/xdc/HTML/sessions.html for my talk :-)
