### PR TITLE
Desktop Project Dark Mode

### DIFF
--- a/Desktop Project/XojoUnitDesktop.xojo_project
+++ b/Desktop Project/XojoUnitDesktop.xojo_project
@@ -1,5 +1,5 @@
 Type=Desktop
-RBProjectVersion=2019.031
+RBProjectVersion=2019.032
 MinIDEVersion=20070100
 OrigIDEVersion=00000000
 Class=App;App.xojo_code;&h000000001BA8AB47;&h0000000000000000;false
@@ -52,6 +52,7 @@ DebuggerCommandLine=
 UseGDIPlus=True
 UseBuildsFolder=True
 HiDPI=True
+DarkMode=True
 CopyRedistNextToWindowsEXE=False
 IsWebProject=False
 LinuxBuildArchitecture=1

--- a/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
+++ b/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
@@ -1493,9 +1493,12 @@ End
 		  #Pragma Unused column
 		  
 		  #If TargetMacOS Then
-		    If row Mod 2 = 0 And Not Me.Selected(row) Then
-		      g.ForeColor = RGB(237, 243, 254) '&cD0D4FF
-		      g.FillRect(0, 0, g.Width, g.Height)
+		    // Only color background in light mode otherwise listbox is unreadable
+		    If isDarkMode = False Then
+		      If row Mod 2 = 0 And Not Me.Selected(row) Then
+		        g.ForeColor = RGB(237, 243, 254) '&cD0D4FF
+		        g.FillRect(0, 0, g.Width, g.Height)
+		      End If
 		    End If
 		    
 		    Return True
@@ -1629,7 +1632,12 @@ End
 		  #Pragma Unused y
 		  
 		  Const kRedColor As Color = &cFF000000
-		  Const kBlackColor As Color = &c00000000
+		  Dim TextColor As Color
+		  If isDarkMode = False Then
+		    TextColor = &c00000000 // Black
+		  Else
+		    TextColor = &cdcdbda // Gray
+		  End If
 		  Static kGreyColor As Color = DisabledTextColor // Pseudo-constant
 		  
 		  If Me.RowTag(row) IsA TestResult Then
@@ -1644,7 +1652,7 @@ End
 		      If tr.Result = TestResult.NotImplemented Then
 		        g.ForeColor = kGreyColor
 		      Else
-		        g.ForeColor = kBlackColor
+		        g.ForeColor = TextColor
 		      End If
 		      g.Bold = Not tr.Message.Empty
 		      


### PR DESCRIPTION
Update to the Desktop project to support Dark Mode in the XojoUnitTestWindow. Without these changes and when running in Dark Mode, the Listbox is mostly unreadable due to the custom colors in the paint events that assume you're in Light Mode.