### PR TITLE
Feature/xojo unit headless

### DIFF
--- a/Shared Resources/XojoUnit/TestFramework/TestController.xojo_code
+++ b/Shared Resources/XojoUnit/TestFramework/TestController.xojo_code
@@ -217,6 +217,7 @@ Protected Class TestController
 		  
 		  Call RunTestCount // Updates all the counts
 		  RaiseEvent AllTestsFinished
+		  RaiseEvent TestResults(mTestGroups)
 		End Sub
 	#tag EndMethod
 
@@ -350,6 +351,10 @@ Protected Class TestController
 
 	#tag Hook, Flags = &h0
 		Event TestFinished(result As TestResult, group As TestGroup)
+	#tag EndHook
+
+	#tag Hook, Flags = &h0
+		Event TestResults(CompleteResult() As TestGroup)
 	#tag EndHook
 
 

--- a/Shared Resources/XojoUnit/TestFramework/TestGroup.xojo_code
+++ b/Shared Resources/XojoUnit/TestFramework/TestGroup.xojo_code
@@ -1,5 +1,32 @@
 #tag Class
 Protected Class TestGroup
+	#tag Method, Flags = &h0
+		Shared Function ArrayToCliString(testGroup() As TestGroup) As String
+		  Var TotalTestGroupResult As String 
+		  
+		  TotalTestGroupResult = TotalTestGroupResult + "----------------------------------------------------------------------------------------------------------" + EndOfLine
+		  
+		  For Each tg As TestGroup In testGroup
+		    
+		    TotalTestGroupResult = TotalTestGroupResult + "  testsuite errors=""0"" skipped=""" + tg.SkippedTestCount.ToText + _
+		    """ tests=""" + tg.TestCount.ToText + _
+		    """ time=""" + tg.Duration.ToText + _
+		    """ failures=""" + tg.FailedTestCount.ToText + _
+		    """ name=""" + tg.Name + """" + EndOfLine
+		    
+		    For Each tr As TestResult In tg.Results
+		      TotalTestGroupResult = TotalTestGroupResult + TestResult.toCliString(tr) + EndOfLine
+		    Next
+		    
+		  Next
+		  
+		  TotalTestGroupResult = TotalTestGroupResult + "----------------------------------------------------------------------------------------------------------" + EndOfLine
+		  Return TotalTestGroupResult
+		  
+		  
+		End Function
+	#tag EndMethod
+
 	#tag Method, Flags = &h1
 		Protected Sub AsyncAwait(maxSeconds As Integer)
 		  If IsRunning Then

--- a/Shared Resources/XojoUnit/TestFramework/TestResult.xojo_code
+++ b/Shared Resources/XojoUnit/TestFramework/TestResult.xojo_code
@@ -1,5 +1,32 @@
 #tag Class
 Protected Class TestResult
+	#tag Method, Flags = &h0
+		Shared Function toCliString(tr As TestResult) As String
+		  Var TotalTestResult As String 
+		  
+		  TotalTestResult =  TotalTestResult + "     name=""" + tr.TestName + """ time=""" + tr.Duration.ToText + _
+		  """ duration= """ + tr.Duration.ToText + """" + EndOfLine // "time" is right, but "duration" is maintained for backwards compatibility
+		  
+		  If tr.Result = TestResult.Skipped Then
+		    TotalTestResult =  TotalTestResult +  "       <skipped />" + EndOfLine
+		    
+		  ElseIf tr.Result = TestResult.NotImplemented Then
+		    TotalTestResult =  TotalTestResult +  "       <not_implemented />" + EndOfLine
+		    
+		  ElseIf tr.Result = TestResult.Failed Then
+		    Dim failMessage As Text = tr.Message
+		    failMessage = failMessage.ReplaceAll("<", "&lt;")
+		    failMessage = failMessage.ReplaceAll(">", "&gt;")
+		    TotalTestResult =  TotalTestResult + "       <failure type=""xojo.AssertionFailedError"" message=""" + failMessage + """/>" + EndOfLine
+		  End If
+		  
+		  TotalTestResult =  TotalTestResult + "    " + EndOfLine
+		  
+		  Return TotalTestResult
+		End Function
+	#tag EndMethod
+
+
 	#tag Property, Flags = &h0
 		Duration As Double
 	#tag EndProperty
@@ -41,14 +68,19 @@ Protected Class TestResult
 	#tag ViewBehavior
 		#tag ViewProperty
 			Name="Duration"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Double"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="IncludeMethod"
+			Visible=false
 			Group="Behavior"
 			InitialValue="True"
 			Type="Boolean"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Index"
@@ -56,6 +88,7 @@ Protected Class TestResult
 			Group="ID"
 			InitialValue="-2147483648"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Left"
@@ -63,10 +96,13 @@ Protected Class TestResult
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Message"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Text"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -74,11 +110,15 @@ Protected Class TestResult
 			Name="Name"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="Result"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Text"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -86,11 +126,15 @@ Protected Class TestResult
 			Name="Super"
 			Visible=true
 			Group="ID"
+			InitialValue=""
 			Type="String"
+			EditorType=""
 		#tag EndViewProperty
 		#tag ViewProperty
 			Name="TestName"
+			Visible=false
 			Group="Behavior"
+			InitialValue=""
 			Type="Text"
 			EditorType="MultiLineEditor"
 		#tag EndViewProperty
@@ -100,6 +144,7 @@ Protected Class TestResult
 			Group="Position"
 			InitialValue="0"
 			Type="Integer"
+			EditorType=""
 		#tag EndViewProperty
 	#tag EndViewBehavior
 End Class

--- a/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
+++ b/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
@@ -1105,7 +1105,6 @@ End
 
 	#tag Method, Flags = &h0
 		Sub RunTestsWithoutGUI()
-		  SelectAllTests()
 		  RunTests()
 		End Sub
 	#tag EndMethod

--- a/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
+++ b/Shared Resources/XojoUnit/XojoUnitTestWindow.xojo_window
@@ -1103,6 +1103,13 @@ End
 		End Sub
 	#tag EndMethod
 
+	#tag Method, Flags = &h0
+		Sub RunTestsWithoutGUI()
+		  SelectAllTests()
+		  RunTests()
+		End Sub
+	#tag EndMethod
+
 	#tag Method, Flags = &h21
 		Private Sub SelectAllGroups(value As Boolean, andTests As Boolean)
 		  For i As Integer = 0 To TestGroupList.ListCount - 1


### PR DESCRIPTION
Dear XojoUnit team, dear Kem,

**currently, we are implementing a continuous integration (CI) solution using XOJOs IDE scripting including automatic builds and tests.** 
As you may know, a proper CI solution also includes the software testing as well. Since the advent of this year, we are using XojoUnit to test our applications and libraries. Unfortunately, we are always creating XOJOs Desktop application projects and we are also tied to this version of XOJOs license. This leads to the problem that we are not able to execute the XojoUnit tests without a GUI. To make it still possible to execute XojoUnit tests in a CLI based console environment used in our CI, we added the following commits: 

- add an additional event (_TestResults in TestController.xojo_code_) to communicate the test results programmatically
- add methods to _TestGroup_ and [TestResult](url) classes to convert them into a String representation